### PR TITLE
Handle expired timers and say how long ago it expired

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -461,11 +461,18 @@ class TimerSkill(MycroftSkill):
             name = timer["name"]
             if not name:
                 name = nice_duration(timer["duration"])
-            remaining = (timer["expires"] - now).seconds
+            remaining = int((timer["expires"] - now).total_seconds())
 
-            self.speak_dialog("time.remaining",
-                              data={"name": name,
-                                    "remaining": nice_duration(remaining)})
+            expired = True if remaining <= 0 else False
+
+            if expired is False:
+                self.speak_dialog("time.remaining",
+                                  data={"name": name,
+                                        "remaining": nice_duration(remaining)})
+            else:
+                self.speak_dialog("timer.expired",
+                                  data={"name": name,
+                                        "ago": nice_duration(-1 * remaining)})
 
     def cancel_timer(self, timer):
         # Cancel given timer

--- a/dialog/en-us/timer.expired.dialog
+++ b/dialog/en-us/timer.expired.dialog
@@ -1,0 +1,1 @@
+The {{name}} timer expired {{ago}} ago


### PR DESCRIPTION
Using `timedelta.seconds` for expired timers results in mycroft starting the timer in reverse and saying there's 23 hours, 59 minutes etc left on the timer. `_speak_timer` now uses `total_seconds()` to handle remaining time correctly.