### PR TITLE
Fix intent tests

### DIFF
--- a/test/intent/002.delete-timer.intent.json
+++ b/test/intent/002.delete-timer.intent.json
@@ -1,6 +1,7 @@
 {
     "utterance": "delete timer",
-    "intent_type": "handle_cancel_timer",
+    "intent_type": "stop.timer.intent",
     "expected_dialog": "cancelled.single.timer",
+    "responses": ["yes"],
     "evaluation_timeout": 10
 }

--- a/test/intent/010.how-much-time-left.intent.json
+++ b/test/intent/010.how-much-time-left.intent.json
@@ -1,8 +1,7 @@
 {
     "utterance": "how much time is left",
     "intent_type": "status.timer.intent",
-    "expected_dialog": "ask.which.timer",
     "responses": ["first"],
-    "expected_dialog": "time.remaining",
+    "expected_dialog": "ask.which.timer",
     "evaluation_timeout": 10
 }


### PR DESCRIPTION
Two intent tests were incorrectly failing.  One was due to the
recent change which allowed a perfect-match Padatious intent
to win instead of Adapt, like it did previously.  So the a
different (but still correct) intent handler was being invoked.

The second change was due to it looking for multiple response
entities.  The test framework really only handles a single one
at the moment.