### PR TITLE
Eliminate disabling of "cancel timer"

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -181,9 +181,7 @@ class TimerSkill(MycroftSkill):
         self.pickle()
         wait_while_speaking()
 
-        self.enable_intent("handle_cancel_timer")
         self.enable_intent("handle_mute_timer")
-        self.enable_intent("handle_status_timer")
 
         # Start showing the remaining time on the faceplate
         self.update_display(None)
@@ -234,9 +232,7 @@ class TimerSkill(MycroftSkill):
             # No active timers, clean up
             self.cancel_scheduled_event('ShowTimer')
             self.displaying_timer = None
-            self.disable_intent("handle_cancel_timer")
             self.disable_intent("handle_mute_timer")
-            # self.disable_intent("handle_status_timer")  # TODO: needs Adapt
             self._stop_beep()
             self.enclosure.eyes_reset()
             self.enclosure.mouth_reset()


### PR DESCRIPTION
The timer would disable the handler for "cancel all timers" when there aren't
any active.  As a result, the alarm skill would match that utterance and it
would trigger an alarm handler.  Besides sounding odd, I believe this was
causing failures of the default skill intent tests.