### PR TITLE
Remove extra brace

### DIFF
--- a/vocab/de-de/status.timer.intent
+++ b/vocab/de-de/status.timer.intent
@@ -7,7 +7,7 @@ status des timers
 welche timer (gibt es|sind aktiv)
 timer status
 status timer
-status des ({duration} timers| timer| timers})
+status des ({duration} timers| timer| timers)
 wie lange noch
 verbleibende zeit von ({duration} timer| timer)
 (wieviel|) zeit (verbleibend|noch|übrig|) (auf|) (timer|{duration} timer|)?

--- a/vocab/en-us/status.timer.intent
+++ b/vocab/en-us/status.timer.intent
@@ -6,7 +6,7 @@
 status of the timers
 (tell me|) timer status
 (tell me|) timer statuses
-(tell me|) status of the ({duration} timer| timer})
+(tell me|) status of the ({duration} timer| timer)
 timer left?
 time remaining on the ({duration} timer| timer)
 time remaining for (timer|{duration} timer|)?


### PR DESCRIPTION
The intent "(tell me|) status of the ({duration} timer| timer})" has an accidental }.