### PR TITLE
Fix vocabulary collision

### DIFF
--- a/vocab/en-us/stop.timer.intent
+++ b/vocab/en-us/stop.timer.intent
@@ -1,4 +1,1 @@
 (stop|end|cancel|abort|delete|kill|turn off) {all|the|} (timer|timers)
-turn it off
-turn off
-cancel


### PR DESCRIPTION
Padatious was over-matching, producing a match for the phrase
"turn off the bedroom light" to the "turn off the timer" phrase.
For now I'm eliminating some of the phrases.