### PR TITLE
Fix typo in vocab

### DIFF
--- a/vocab/en-us/stop.timer.intent
+++ b/vocab/en-us/stop.timer.intent
@@ -1,1 +1,2 @@
-(stop|end|cancel|abort|delete|kill|turn off) {all|the|} (timer|timers)
+(stop|end|cancel|abort|delete|kill|turn off) (all|the|) (timer|timers)
+


### PR DESCRIPTION
Accidentally used {} instead of ()