### PR TITLE
add final cancel all timers

### DIFF
--- a/test/intent/015.cancel-all-timers.intent.json
+++ b/test/intent/015.cancel-all-timers.intent.json
@@ -1,0 +1,6 @@
+{
+    "utterance": "cancel all timers",
+    "intent_type": "stop.timer.intent",
+    "responses": ["yes"],
+    "evaluation_timeout": 10
+}


### PR DESCRIPTION
Had a user report their device was announcing that a number of timers had finished on boot. They were clearly the timers from the integration tests. 

This shouldn't be happening, but I wonder if it would help to have a final cancel all timers in the integration tests so that the created timers are cleared after each test run?

What do you think @forslund? 