### PR TITLE
Add missing set keyword

### DIFF
--- a/vocab/en-us/start.timer.intent
+++ b/vocab/en-us/start.timer.intent
@@ -1,8 +1,8 @@
 (another|one more|second|third|fourth|fifth|) timer ((for |){duration}|)
 ping me in {duration}
-(start|create) (a|) timer
-(start|create) (a|) timer for {duration}
-(start|create) (a|) timer (for|called|named) {name}
-(start|create) (a|) {duration} timer
-(start|create) (a|) {duration} timer (for|called|named) {name}
-(start|create) (a|) timer (for|called|named) {name} for {duration}
+(set|start|create) (a|) timer
+(set|start|create) (a|) timer for {duration}
+(set|start|create) (a|) timer (for|called|named) {name}
+(set|start|create) (a|) {duration} timer
+(set|start|create) (a|) {duration} timer (for|called|named) {name}
+(set|start|create) (a|) timer (for|called|named) {name} for {duration}


### PR DESCRIPTION
The "set" keyword was missing from en-us, even though the README example calls it out.  Without this fix if you do a "set timer for 30 minutes" it will do the wrong thing.