### PR TITLE
Prevent expired timer beep between wake word and 'stop'

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -115,7 +115,32 @@ class TimerSkill(MycroftSkill):
         self.is_listening = True
 
     def handle_listener_ended(self, message):
-        self.is_listening = False
+        def set_is_listening():
+            self.is_listening = False
+
+        def wait_for_speak(timeout=8):
+            """Wait for a speak Message on the bus.
+
+            Arguments:
+                timeout (int): how long to wait, defaults to 8 sec
+            """
+            speak_msg_detected = False
+
+            def detected_speak(message=None):
+                nonlocal speak_msg_detected
+                speak_msg_detected = True
+            self.bus.on('speak', detected_speak)
+            time.sleep(timeout)
+            self.bus.remove('speak', detected_speak)
+            return speak_msg_detected
+
+        if self.beep_process is not None:
+            self.bus.on('recognizer_loop:speech.recognition.unknown',
+                        set_is_listening)
+            speak_msg_detected = wait_for_speak()
+            self.bus.remove('recognizer_loop:speech.recognition.unknown',
+                            set_is_listening)
+        set_is_listening()
 
     def _extract_duration(self, text):
         """Extract duration in seconds.

--- a/__init__.py
+++ b/__init__.py
@@ -36,8 +36,12 @@ try:
 except ImportError:
     from mycroft.skills.skill_data import to_letters as to_alnum
 
+from .util.bus import wait_for_message
+
+
 ONE_HOUR = 3600
 ONE_MINUTE = 60
+
 
 # TESTS
 #  0: cancel all timers
@@ -111,36 +115,20 @@ class TimerSkill(MycroftSkill):
                 self.timer_index = timer["index"]
 
     # TODO: Implement util.is_listening() to replace this
+    def is_not_listening(self):
+        self.is_listening = False
+
     def handle_listener_started(self, message):
         self.is_listening = True
 
     def handle_listener_ended(self, message):
-        def set_is_listening():
-            self.is_listening = False
-
-        def wait_for_speak(timeout=8):
-            """Wait for a speak Message on the bus.
-
-            Arguments:
-                timeout (int): how long to wait, defaults to 8 sec
-            """
-            speak_msg_detected = False
-
-            def detected_speak(message=None):
-                nonlocal speak_msg_detected
-                speak_msg_detected = True
-            self.bus.on('speak', detected_speak)
-            time.sleep(timeout)
-            self.bus.remove('speak', detected_speak)
-            return speak_msg_detected
-
         if self.beep_process is not None:
             self.bus.on('recognizer_loop:speech.recognition.unknown',
-                        set_is_listening)
-            speak_msg_detected = wait_for_speak()
+                        self.is_not_listening)
+            speak_msg_detected = wait_for_message(self.bus, 'speak')
             self.bus.remove('recognizer_loop:speech.recognition.unknown',
-                            set_is_listening)
-        set_is_listening()
+                            self.is_not_listening)
+        self.is_not_listening()
 
     def _extract_duration(self, text):
         """Extract duration in seconds.

--- a/util/bus.py
+++ b/util/bus.py
@@ -1,0 +1,21 @@
+from time import sleep
+
+# TODO remove this in v20.8 when it should be available in mycroft-core
+
+def wait_for_message(bus, message_type, timeout=8):
+    """Wait for specified Message type on the bus.
+
+    Arguments:
+        bus: an instance of the message bus to listen on
+        message_type: the Message type to wait for
+        timeout (int): how long to wait, defaults to 8 secs
+    """
+    message_detected = False
+
+    def detected_speak(message=None):
+        nonlocal message_detected
+        message_detected = True
+    bus.on(message_type, detected_speak)
+    sleep(timeout)
+    bus.remove(message_type, detected_speak)
+    return message_detected


### PR DESCRIPTION
This prevents the timer expired beeping from playing while the user is interacting with the device. 

Similar to the new process in mycroft-core, this will silence the beeping following a mic activation. 
- If no STT is returned it will resume beeping immediately. 
- If an utterance is received it will allow up to 8 seconds for a response to be made. This gives sufficient time for "stop", or even "what time is it".
- The expired timer beeping will resume following some dialog being spoken or after 8 seconds if no other activity takes place.

