### PR TITLE
Bugfix/triggering on alarm utterances

### DIFF
--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -112,7 +112,7 @@ def then_wait_fail(msg_type, criteria_func, context, timeout=10):
         tuple (bool, str) test status and debug output
     """
     status, debug = then_wait(msg_type, criteria_func, context, timeout)
-    return (not status, debug)
+    return not status, debug
 
 # NOTE: language here has been changed to avoid conflict with soon to be merged VK Step.
 # When this code is removed, change this back to "Skill should not reply"
@@ -125,7 +125,7 @@ def then_do_not_respond(context, skill):
         skill_responded = skill == msg_skill
         debug_msg = ("{} responded with '{}'. \n".format(skill, utt)
                      if skill_responded else '')
-        return (skill_responded, debug_msg)
+        return skill_responded, debug_msg
 
     passed, debug = then_wait_fail('speak', check_all_dialog, context)
     if not passed:

--- a/test/behave/timer.feature
+++ b/test/behave/timer.feature
@@ -474,3 +474,14 @@ Feature: mycroft-timer
   Examples: status of two timers
      | what's the status of the timers |
      | what's the status of the timers |
+
+  Scenario Outline: Setting alarms
+    Given an english speaking user
+     When the user says "<set an alarm>"
+     Then "TimerSkill" should not respond
+
+    Examples:
+      | set an alarm |
+      | create an alarm |
+      | create an alarm for 7:30 am |
+      | create a repeating alarm for weekdays |

--- a/test/behave/timer.feature
+++ b/test/behave/timer.feature
@@ -349,18 +349,6 @@ Feature: mycroft-timer
      | I got it |
      | mute |
      | disable |
-
-   @xfail
-   # Jira MS-62 https://mycroft.atlassian.net/browse/MS-62
-  Scenario Outline: Failed stop an expired timer from beeping
-    Given an english speaking user
-      And no timers are previously set
-      And a timer is expired
-      When the user says "<stop timer>"
-      Then "mycroft-timer" should stop beeping
-
-   Examples: stop timer
-     | stop timer |
      | that's enough |
 
   Scenario Outline: status of a single timer

--- a/vocab/en-us/StopBeeping.voc
+++ b/vocab/en-us/StopBeeping.voc
@@ -4,3 +4,6 @@ kill it
 stop
 shut up
 cancel
+disable
+mute
+enough

--- a/vocab/en-us/start.timer.intent
+++ b/vocab/en-us/start.timer.intent
@@ -1,8 +1,8 @@
 (another|one more|second|third|fourth|fifth|) timer ((for |){duration}|)
 ping me in {duration}
-(set|start|create) (a|) timer
-(set|start|create) (a|) timer for {duration}
-(set|start|create) (a|) timer (for|called|named) {name}
-(set|start|create) (a|) {duration} timer
-(set|start|create) (a|) {duration} timer (for|called|named) {name}
-(set|start|create) (a|) timer (for|called|named) {name} for {duration}
+timer
+timer for {duration}
+timer (for|called|named) {name}
+timer (for|called|named) {name} for {duration}
+{duration} (second|minute|hour) timer
+{duration} timer (for|called|named) {name}


### PR DESCRIPTION
Timer Skill was sometimes triggering on utterances intended for the Alarm. 

This appears to be caused by the Padatious intent. The example phrases causing the match should already be caught by the general Adapt intents "Create/Set/Start" + "Timer". So have removed that.

Also added tests for these phrases to test in isolation, such as when the Alarm Skill has been blacklisted.

Was also seeing some "stop beeping" tests failing in certain circumstances locally so have included those more explicitly in the vocab and fixed a test marked `xfail` that seemed to be caused by the same issue.