### PR TITLE
Remove wait_for_message and clear xfails

### DIFF
--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -3,8 +3,9 @@ import time
 from behave import given, then
 
 from mycroft.audio import wait_while_speaking
-from test.integrationtests.voight_kampff import (emit_utterance,
-     mycroft_responses, then_wait, wait_for_dialog)
+from test.integrationtests.voight_kampff import (
+        emit_utterance,
+        wait_for_dialog)
 
 
 @given('a {timer_length} timer is set')
@@ -96,39 +97,3 @@ def then_stop_beeping(context):
         time.sleep(1)
     else:
         assert False, "Timer is still ringing"
-
-# TODO remove from Skill once included in Mycroft-core
-def then_wait_fail(msg_type, criteria_func, context, timeout=10):
-    """Wait for a specified time, failing if criteria is fulfilled.
-
-    Arguments:
-        msg_type: message type to watch
-        criteria_func: Function to determine if a message fulfilling the
-                       test case has been found.
-        context: behave context
-        timeout: Time allowance for a message fulfilling the criteria
-
-    Returns:
-        tuple (bool, str) test status and debug output
-    """
-    status, debug = then_wait(msg_type, criteria_func, context, timeout)
-    return not status, debug
-
-# NOTE: language here has been changed to avoid conflict with soon to be merged VK Step.
-# When this code is removed, change this back to "Skill should not reply"
-@then('"{skill}" should not respond')
-def then_do_not_respond(context, skill):
-
-    def check_all_dialog(message):
-        msg_skill = message.data.get('meta').get('skill')
-        utt = message.data['utterance'].lower()
-        skill_responded = skill == msg_skill
-        debug_msg = ("{} responded with '{}'. \n".format(skill, utt)
-                     if skill_responded else '')
-        return skill_responded, debug_msg
-
-    passed, debug = then_wait_fail('speak', check_all_dialog, context)
-    if not passed:
-        assert_msg = debug
-        assert_msg += mycroft_responses(context)
-    assert passed, assert_msg or '{} responded'.format(skill)

--- a/test/behave/timer.feature
+++ b/test/behave/timer.feature
@@ -430,7 +430,7 @@ Feature: mycroft-timer
   Scenario Outline: Setting alarms
     Given an english speaking user
      When the user says "<set an alarm>"
-     Then "TimerSkill" should not respond
+     Then "TimerSkill" should not reply
 
     Examples:
       | set an alarm |

--- a/test/behave/timer.feature
+++ b/test/behave/timer.feature
@@ -293,18 +293,6 @@ Feature: mycroft-timer
      | disable the pasta timer |
      | delete the pasta timer |
      | remove pasta timer |
-
-  @xfail
-  # Jira MS-113 https://mycroft.atlassian.net/browse/MS-113
-  Scenario Outline: Failing cancel a named timer
-    Given an english speaking user
-      And no timers are previously set
-      And a timer named pasta is set
-      When the user says "<cancel a named timer>"
-      Then "mycroft-timer" should reply with dialog from "cancelled.single.timer.dialog"
-
-   Examples: cancel a named timer
-     | cancel a named timer |
      | end pasta timer |
      | end the pasta timer |
 
@@ -368,18 +356,6 @@ Feature: mycroft-timer
      | are there any timers |
      | what timers do I have |
      | when does the timer end |
-
-  @xfail
-  # Jira MS-92 https://mycroft.atlassian.net/browse/MS-92
-  Scenario Outline: Failing status of a single timer
-    Given an english speaking user
-      And no timers are previously set
-      And a timer is set for 5 minutes
-      When the user says "<timer status>"
-      Then "mycroft-timer" should reply with dialog from "time.remaining.dialog"
-
-   Examples: status of a single timer
-     | timer status |
      | timer status |
 
   Scenario Outline: status when there are no active timers
@@ -399,18 +375,6 @@ Feature: mycroft-timer
      | are there any timers |
      | what timers do I have |
      | when does the timer end |
-
-  @xfail
-  # Jira MS-94 https://mycroft.atlassian.net/browse/MS-94
-  Scenario Outline: Failing status when there are no active timers
-    Given an english speaking user
-      And no timers are previously set
-      And no timers are set
-      When the user says "<timer status>"
-      Then "mycroft-timer" should reply with dialog from "no.active.timer.dialog"
-
-   Examples: status when there are no active timers
-     | timer status |
      | timer status |
 
   Scenario Outline: status of named timer

--- a/vocab/en-us/Cancel.voc
+++ b/vocab/en-us/Cancel.voc
@@ -7,3 +7,4 @@ clear
 disable
 disabled
 remove
+end

--- a/vocab/en-us/stop.timer.intent
+++ b/vocab/en-us/stop.timer.intent
@@ -1,4 +1,5 @@
-(stop|end|cancel|abort|delete|kill|turn off) (all|the|) (timer|timers)
+(stop|end|cancel|abort|delete|disable|kill|turn off) (all|the|) (timer|timers)
+(stop|end|cancel|abort|delete|disable|kill|turn off)( the|) {duration_or_name} (timer|timers)
 turn it off
 silence
 shutup

--- a/vocab/en-us/timer.status.intent
+++ b/vocab/en-us/timer.status.intent
@@ -2,3 +2,5 @@ how (much time|long) (is|) (left|remaining)
 how's (my|the) {name} timer
 how's (my|the) timer
 when (does|will) (my|the) timer (end|finish)
+timer status
+status of timer


### PR DESCRIPTION
Removes the `wait_for_message` method and custom "skill should not respond" Step as these have been added to Mycroft-core in v20.08.

Also had some tests randomly fail so added some better vocab and cleared a few of the expected failing tests.