### PR TITLE
Add stronger Padatious intent for status

### DIFF
--- a/vocab/en-us/timer.status.intent
+++ b/vocab/en-us/timer.status.intent
@@ -1,4 +1,5 @@
 how (much time|long) (is|) (left|remaining)
+how (much|much time|long) (is|) (left|remaining) on (my|the|) {name} timer
 how's (my|the) {name} timer
 how's (my|the) timer
 when (does|will) (my|the) timer (end|finish)


### PR DESCRIPTION
The {duration} entity in the Padatious set timer intent is over matching on any phrase. 

Eg: "how much time is left on the 5 minute timer" => duration == "how much time is left on the 5 minute"

This provides a short term fix by adding more specific language for the equivalent status intent.

**To test**
See tests 11 and 12 in the old integration tests.