### PR TITLE
Stop Skill speaking over next VK test

### DIFF
--- a/test/behave/timer.feature
+++ b/test/behave/timer.feature
@@ -431,6 +431,7 @@ Feature: mycroft-timer
     Given an english speaking user
      When the user says "<set an alarm>"
      Then "TimerSkill" should not reply
+     When the user says "cancel"
 
     Examples:
       | set an alarm |


### PR DESCRIPTION
As this test continues to try and get an answer on its previous query, any tests following it that are attempting to detect dialog receive the additional prompts from this test instead.

This can be seen is [this Allure Timeline output](https://hudson.mycroft.team/job/mycroft-skills/job/PR-1406/3/allure/#timeline). You can also generate it locally by running the VK tests for fallback-unknown and this small scenario from the Timer Skill.

In the longer term we should find a way to properly isolate tests from each other.