### PR TITLE
Fix Mark II screen was going blank after cancelling timers

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -882,7 +882,7 @@ class TimerSkill(MycroftSkill):
             self.active_timers.remove(timer)
             if len(self.active_timers) == 0:
                 if self.screen_showing:
-                    self.gui.clear()
+                    self.gui.release()
                     self.screen_showing = False
                 self.timer_index = 0  # back to zero timers
                 self.enclosure.eyes_on()  # reset just in case


### PR DESCRIPTION
#### Description
Fixes https://github.com/MycroftAI/hardware-mycroft-mark-II/issues/27

#### Type of PR
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Activate the timer skill with one or more timers.  When the last timer is cancelled, the idle screen should reappear.

#### Documentation
N/A
