### PR TITLE
Fixed name of dialog file that was still using the old convention.

### DIFF
--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -91,7 +91,7 @@ def _cancel_all_timers(context):
 def let_timer_expire(context):
     """Start a short timer and let it expire to test expiration logic."""
     emit_utterance(context.bus, "set a 3 second timer")
-    expected_response = ["started.timer"]
+    expected_response = ["started-timer"]
     match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
     assert match_found, format_dialog_match_error(expected_response, speak_messages)
     time.sleep(4)


### PR DESCRIPTION
#### Description
Fixes a bug that caused VK test failures due to an incorrectly named dialog file.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
VK tests for expired timers should pass.

#### Documentation
N/A
