### PR TITLE
fix failing tests for canceling an expired timer

### DIFF
--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -77,6 +77,19 @@ def reset_timers(context):
     _cancel_all_timers(context)
 
 
+@given("an expired timer")
+def let_timer_expire(context):
+    """Start a short timer and let it expire to test expiration logic."""
+    _cancel_all_timers(context)
+    emit_utterance(context.bus, "set a 3 second timer")
+    expected_response = ["started-timer"]
+    match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
+    assert match_found, format_dialog_match_error(expected_response, speak_messages)
+    expected_response = ["timer-expired"]
+    match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
+    assert match_found, format_dialog_match_error(expected_response, speak_messages)
+
+
 def _cancel_all_timers(context):
     """Cancel all active timers.
 
@@ -87,17 +100,7 @@ def _cancel_all_timers(context):
     assert match_found, format_dialog_match_error(CANCEL_RESPONSES, speak_messages)
 
 
-@given("a timer is expired")
-def let_timer_expire(context):
-    """Start a short timer and let it expire to test expiration logic."""
-    emit_utterance(context.bus, "set a 3 second timer")
-    expected_response = ["started-timer"]
-    match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
-    assert match_found, format_dialog_match_error(expected_response, speak_messages)
-    time.sleep(4)
-
-
-@then('"mycroft-timer" should stop beeping')
+@then('the expired timer should stop beeping')
 def then_stop_beeping(context):
     # TODO: Better check!
     import psutil

--- a/test/behave/stop_expired_timer.feature
+++ b/test/behave/stop_expired_timer.feature
@@ -1,26 +1,37 @@
 Feature: Stop an expired timer
   After a timer expires, a beeping alarm is played.  Stop the beeping and cancel the
-  expired timer.
+  expired timer.  This can be done in two ways.  First is the generic "stop" command.
+  Second is using one of the accepted timer cancel utterances.
 
-  Scenario Outline: stop an expired timer from beeping
+  Scenario Outline: stop an expired timer using a "stop" command
     Given an english speaking user
-    And a timer is expired
-    When the user says "<stop timer>"
-    Then "mycroft-timer" should stop beeping
+    And an expired timer
+    When the user says "<stop request>"
+    Then the expired timer should stop beeping
 
-    Examples: stop timer
-      | stop timer |
-      | stop timer |
+    Examples:
+      | stop request |
       | stop |
       | cancel |
-      | end timer |
       | turn it off |
       | silence |
       | shut up |
-      | cancel all timers |
-      | cancel the timers |
-      | cancel timers |
       | I got it |
       | mute |
       | disable |
       | that's enough |
+
+  Scenario Outline: stop an expired timer using a "cancel" command.
+    Given an english speaking user
+    And an expired timer
+    When the user says "<cancel request>"
+    Then the expired timer should stop beeping
+    And "mycroft-timer" should reply with dialog from "cancelled-single-timer.dialog"
+
+    Examples:
+      | cancel request |
+      | stop timer |
+      | end timer |
+      | cancel all timers |
+      | cancel the timers |
+      | cancel timers |


### PR DESCRIPTION
#### Description
Expiring timer tests were failing because of a new dialog that announced the expired timer.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [X] Test improvements

#### Testing
Run the VK tests for this skill.  all should pass

#### Documentation
N/A
