### PR TITLE
Test: Make check for timer not stopping event driven

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -78,6 +78,7 @@ class TimerSkill(MycroftSkill):
         )
         self.add_event("speak", self.handle_speak)
         self.add_event("skill.timer.stop", self.handle_timer_stop)
+        self.add_event("skill.timer.play_beep", self.handle_play_beep)
 
     @intent_handler(AdaptIntent().optionally("start").require("timer"))
     def handle_start_timer_generic(self, message: Message):
@@ -723,6 +724,11 @@ class TimerSkill(MycroftSkill):
 
         return timers_to_display
 
+    def handle_play_beep(self, _):
+        """Event handler for starting event playback."""
+        play_proc = play_wav(str(self.sound_file_path))
+        play_proc.wait()
+
     def check_for_expired_timers(self):
         """Provide a audible and visual indicator when one or more timers expire.
 
@@ -730,11 +736,10 @@ class TimerSkill(MycroftSkill):
         """
         expired_timers = [timer for timer in self.active_timers if timer.expired]
         if expired_timers:
-            play_proc = play_wav(str(self.sound_file_path))
+            self.bus.emit(Message("skill.timer.play_beep"))
             if self.platform == MARK_I:
                 self._flash_eyes()
             self._speak_expired_timer(expired_timers)
-            play_proc.wait()
 
     def _flash_eyes(self):
         """Flash the eyes (if supported) as a visual indicator that a timer expired."""

--- a/__init__.py
+++ b/__init__.py
@@ -730,10 +730,11 @@ class TimerSkill(MycroftSkill):
         """
         expired_timers = [timer for timer in self.active_timers if timer.expired]
         if expired_timers:
-            play_wav(str(self.sound_file_path))
+            play_proc = play_wav(str(self.sound_file_path))
             if self.platform == MARK_I:
                 self._flash_eyes()
             self._speak_expired_timer(expired_timers)
+            play_proc.wait()
 
     def _flash_eyes(self):
         """Flash the eyes (if supported) as a visual indicator that a timer expired."""


### PR DESCRIPTION
#### Description
This is an option to make the "still beeping" check suggested by @chrisveilleux event-driven.

Pros:
Kind of simple

Cons:
Looks at an intermediary bus message instead of checking the actual playback.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
_Either delete those that do not apply, or add an x between the square brackets like so: `- [x]`_
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ x ] Test improvements

#### Testing
Run the VK tests for the skill make sure that some of the cancel expired timer tests works. There are some of those tests that uses unrecognized vocabulary (at least on my machine) so all till not pass. But make sure if the vocab fails the test should also fail.