### PR TITLE
Added an event indicating when an expired timer is stopped.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -521,7 +521,7 @@ class TimerSkill(MycroftSkill):
         else:
             self.speak_dialog("cancel-all", data={"count": len(self.active_timers)})
         if self.expired_timers:
-            self.bus.emit(Message("timer.stopped-expired"))
+            self.bus.emit(Message("skill.timer.stopped-expired"))
         self.active_timers = list()
 
     def _cancel_single_timer(self, utterance: str):
@@ -542,7 +542,7 @@ class TimerSkill(MycroftSkill):
                 timer = None
         if timer is not None:
             if timer in self.expired_timers:
-                self.bus.emit(Message("timer.stopped-expired"))
+                self.bus.emit(Message("skill.timer.stopped-expired"))
             self.active_timers.remove(timer)
             self.speak_dialog("cancelled-single-timer")
 
@@ -598,7 +598,7 @@ class TimerSkill(MycroftSkill):
         if matches:
             timer = matches[0]
             if timer in self.expired_timers:
-                self.bus.emit(Message("timer.stopped-expired"))
+                self.bus.emit(Message("skill.timer.stopped-expired"))
             self.active_timers.remove(timer)
             dialog = TimerDialog(timer, self.lang)
             dialog.build_cancel_dialog()
@@ -802,7 +802,7 @@ class TimerSkill(MycroftSkill):
         """The user wants the beeping to stop so cancel all expired timers."""
         for timer in self.expired_timers:
             self.active_timers.remove(timer)
-        self.bus.emit(Message("timer.stopped-expired"))
+        self.bus.emit(Message("skill.timer.stopped-expired"))
         self._save_timers()
         if not self.active_timers:
             self._reset()

--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -1,12 +1,12 @@
-import time
-from typing import List
+"""Steps to support the Timer Skill feature files."""
+from typing import Any, List
 
 from behave import given, then
 
 from test.integrationtests.voight_kampff import (
     emit_utterance,
-    format_dialog_match_error,
-    wait_for_dialog_match,
+    VoightKampffDialogMatcher,
+    VoightKampffEventMatcher,
 )
 
 CANCEL_RESPONSES = (
@@ -19,95 +19,95 @@ CANCEL_RESPONSES = (
 
 
 @given("an active {duration} timer")
-def start_single_timer(context, duration):
+def start_single_timer(context: Any, duration: str):
     """Clear any active timers and start a single timer for a specified duration."""
     _cancel_all_timers(context)
     _start_a_timer(
-        context.bus, utterance="set a timer for " + duration, response=["started-timer"]
+        context, utterance="set a timer for " + duration, response=["started-timer"]
     )
 
 
 @given("an active timer named {name}")
-def start_single_named_timer(context, name):
+def start_single_named_timer(context: Any, name: str):
     """Clear any active timers and start a single named timer for 90 minutes."""
     _cancel_all_timers(context)
     _start_a_timer(
-        context.bus,
+        context,
         utterance="set a timer for 90 minutes named " + name,
         response=["started-timer-named"],
     )
 
 
 @given("an active timer for {duration} named {name}")
-def start_single_named_dialog_timer(context, duration, name):
+def start_single_named_dialog_timer(context: Any, duration: str, name: str):
     """Clear any active timers and start a single named timer for specified duration."""
     _cancel_all_timers(context)
     _start_a_timer(
-        context.bus,
+        context,
         utterance=f"set a timer for {duration} named {name}",
         response=["started-timer-named"],
     )
 
 
 @given("multiple active timers")
-def start_multiple_timers(context):
+def start_multiple_timers(context: Any):
     """Clear any active timers and start multiple timers by duration."""
     _cancel_all_timers(context)
     for row in context.table:
         _start_a_timer(
-            context.bus,
+            context,
             utterance="set a timer for " + row["duration"],
             response=["started-timer", "started-timer-named"],
         )
 
 
-def _start_a_timer(bus, utterance: str, response: List[str]):
+def _start_a_timer(context, utterance: str, response: List[str]):
     """Helper function to start a timer.
 
     If one of the expected responses is not spoken, cause the step to error out.
     """
-    emit_utterance(bus, utterance)
-    match_found, speak_messages = wait_for_dialog_match(bus, response)
-    assert match_found, format_dialog_match_error(response, speak_messages)
+    emit_utterance(context.bus, utterance)
+    dialog_matcher = VoightKampffDialogMatcher(context, response)
+    dialog_matcher.match()
+    assert dialog_matcher.match_found, dialog_matcher.error_message
 
 
 @given("no active timers")
-def reset_timers(context):
+def reset_timers(context: Any):
     """Cancel all active timers to test how skill behaves when no timers are set."""
     _cancel_all_timers(context)
 
 
 @given("an expired timer")
-def let_timer_expire(context):
+def let_timer_expire(context: Any):
     """Start a short timer and let it expire to test expiration logic."""
     _cancel_all_timers(context)
     emit_utterance(context.bus, "set a 3 second timer")
     expected_response = ["started-timer"]
-    match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
-    assert match_found, format_dialog_match_error(expected_response, speak_messages)
+    dialog_matcher = VoightKampffDialogMatcher(context, expected_response)
+    dialog_matcher.match()
+    assert dialog_matcher.match_found, dialog_matcher.error_message
     expected_response = ["timer-expired"]
-    match_found, speak_messages = wait_for_dialog_match(context.bus, expected_response)
-    assert match_found, format_dialog_match_error(expected_response, speak_messages)
+    dialog_matcher = VoightKampffDialogMatcher(context, expected_response)
+    dialog_matcher.match()
+    assert dialog_matcher.match_found, dialog_matcher.error_message
 
 
-def _cancel_all_timers(context):
+def _cancel_all_timers(context: Any):
     """Cancel all active timers.
 
     If one of the expected responses is not spoken, cause the step to error out.
     """
     emit_utterance(context.bus, "cancel all timers")
-    match_found, speak_messages = wait_for_dialog_match(context.bus, CANCEL_RESPONSES)
-    assert match_found, format_dialog_match_error(CANCEL_RESPONSES, speak_messages)
+    dialog_matcher = VoightKampffDialogMatcher(context, CANCEL_RESPONSES)
+    dialog_matcher.match()
+    assert dialog_matcher.match_found, dialog_matcher.error_message
 
 
-@then('the expired timer should stop beeping')
-def then_stop_beeping(context):
-    # TODO: Better check!
-    import psutil
-
-    for i in range(10):
-        if "paplay" not in [p.name() for p in psutil.process_iter()]:
-            break
-        time.sleep(1)
-    else:
-        assert False, "Timer is still ringing"
+@then("the expired timer is no longer active")
+def check_expired_timer_removal(context: Any):
+    """Confirm that expired timers have been cleared when requested."""
+    expected_event = "timer.stopped-expired"
+    event_matcher = VoightKampffEventMatcher(expected_event, context)
+    event_matcher.match()
+    assert event_matcher.match_found, event_matcher.error_message

--- a/test/behave/steps/timer.py
+++ b/test/behave/steps/timer.py
@@ -4,7 +4,7 @@ from typing import Any, List
 from behave import given, then
 
 from test.integrationtests.voight_kampff import (
-    emit_utterance, match_dialog, match_message
+    emit_utterance, VoightKampffDialogMatcher, VoightKampffMessageMatcher
 )
 
 CANCEL_RESPONSES = [
@@ -65,7 +65,8 @@ def _start_a_timer(context, utterance: str, response: List[str]):
     If one of the expected responses is not spoken, cause the step to error out.
     """
     emit_utterance(context.bus, utterance)
-    match_found, error_message = match_dialog(context, response)
+    dialog_matcher = VoightKampffDialogMatcher(context, response)
+    match_found, error_message = dialog_matcher.match()
     assert match_found, error_message
 
 
@@ -81,10 +82,12 @@ def let_timer_expire(context: Any):
     _cancel_all_timers(context)
     emit_utterance(context.bus, "set a 3 second timer")
     expected_response = ["started-timer"]
-    match_found, error_message = match_dialog(context, expected_response)
+    dialog_matcher = VoightKampffDialogMatcher(context, expected_response)
+    match_found, error_message = dialog_matcher.match()
     assert match_found, error_message
     expected_response = ["timer-expired"]
-    match_found, error_message = match_dialog(context, expected_response)
+    dialog_matcher = VoightKampffDialogMatcher(context, expected_response)
+    match_found, error_message = dialog_matcher.match()
     assert match_found, error_message
 
 
@@ -94,7 +97,8 @@ def _cancel_all_timers(context: Any):
     If one of the expected responses is not spoken, cause the step to error out.
     """
     emit_utterance(context.bus, "cancel all timers")
-    match_found, error_message = match_dialog(context, CANCEL_RESPONSES)
+    dialog_matcher = VoightKampffDialogMatcher(context, CANCEL_RESPONSES)
+    match_found, error_message = dialog_matcher.match()
     assert match_found, error_message
 
 
@@ -102,5 +106,6 @@ def _cancel_all_timers(context: Any):
 def check_expired_timer_removal(context: Any):
     """Confirm that expired timers have been cleared when requested."""
     expected_event = "timer.stopped-expired"
-    match_found, error_message = match_message(expected_event, context)
+    message_matcher = VoightKampffMessageMatcher(expected_event, context)
+    match_found, error_message = message_matcher.match()
     assert match_found, error_message

--- a/test/behave/stop_expired_timer.feature
+++ b/test/behave/stop_expired_timer.feature
@@ -7,15 +7,26 @@ Feature: Stop an expired timer
     Given an english speaking user
     And an expired timer
     When the user says "<stop request>"
-    Then the expired timer should stop beeping
+    Then the expired timer is no longer active
 
     Examples:
       | stop request |
       | stop |
-      | cancel |
-      | turn it off |
       | silence |
       | shut up |
+
+  @xfail
+  # Jira SKILL-271 https://mycroft.atlassian.net/browse/SKILL-271
+  Scenario Outline: Failing stop an expired timer using a "stop" command
+    Given an english speaking user
+    And an expired timer
+    When the user says "<stop request>"
+    Then the expired timer is no longer active
+
+    Examples:
+      | stop request |
+      | cancel |
+      | turn it off |
       | I got it |
       | mute |
       | disable |
@@ -25,7 +36,7 @@ Feature: Stop an expired timer
     Given an english speaking user
     And an expired timer
     When the user says "<cancel request>"
-    Then the expired timer should stop beeping
+    Then the expired timer is no longer active
     And "mycroft-timer" should reply with dialog from "cancelled-single-timer.dialog"
 
     Examples:


### PR DESCRIPTION
#### Description
The VoightKampff tests for this skill were producing false positives in the tests that check for stopping an expired timer.  Added a `timer.stopped-expired` event that is emitted when any expired timer is stopped.  The tests now check for this event rather than the existence of a beeping sound to determine if an expired timer was successfully stopped.

During testing of this PR, it was determined that several of the "stop" commands that have been passing should not be.  These are words that are not included in the vocabulary of the Stop Skill (a.k.a. System Skill).  They have been marked as "expected fail" temporarily.

This PR is dependent on [Mycroft Core PR 3002](https://github.com/MycroftAI/mycroft-core/pull/3002).

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [ ] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [X] Test improvements

#### Testing
Run the VK tests with a version of core that includes the changes in the aforementioned PR.

#### Documentation
Docstrings have been included in all the new testing code.
