### PR TITLE
change expiration check timing on wake word activation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -194,6 +194,9 @@ class TimerSkill(MycroftSkill):
             self.active_timers.append(timer)
             self.active_timers.sort(key=lambda tmr: tmr.expiration)
             if len(self.active_timers) == 1:
+                # the expiration checker isn't started here because it is started
+                # in a speech event handler and the new timer is not spoken until
+                # after the display starts.
                 self._show_gui()
                 self._start_display_update()
             self._speak_new_timer(timer)
@@ -474,10 +477,9 @@ class TimerSkill(MycroftSkill):
         Args:
             timer: timer the status will be communicated for
         """
-        # TODO: stop beeping before speaking
         # TODO: speak_dialog should have option to not show mouth
-        # For now, just deactivate.  The sleep() is to allow the
-        # message to make it across the bus first.
+        #   For now, just deactivate.  The sleep() is to allow the
+        #   message to make it across the bus first.
         self.enclosure.deactivate_mouth_events()
         time.sleep(0.25)
         dialog = TimerDialog(timer, self.lang)
@@ -827,9 +829,10 @@ class TimerSkill(MycroftSkill):
         The Mark I performs display events while listening and thinking.  Pause the
         display of the timer to allow these events to display instead.
         """
-        self._stop_expiration_check()
-        if self.platform == MARK_I:
-            self._stop_display_update()
+        if self.active_timers:
+            self._stop_expiration_check()
+            if self.platform == MARK_I:
+                self._stop_display_update()
 
     def handle_speech_recognition_unknown(self, _):
         """React to no request being spoken after the wake word is activated.


### PR DESCRIPTION
#### Description
A log message emitted when the expiration check stops resulting from a wake word activation is confusing users.  Especially when no timers are active.  Change the code that stops the expiration check when wake word is activated to only stop it if there are active timers.

Fixes #104 

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [x] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Trigger wake word with no timers running, log message should not appear.  Trigger wake word with a timer running, log message should appear.

#### Documentation
Documentation exists
