### PR TITLE
"all" in the middle of a word like "sally" matches all timers.

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -494,8 +494,9 @@ class TimerSkill(MycroftSkill):
             message: Message Bus event information from the intent parser
         """
         utterance = message.data["utterance"]
+        utterance_words = utterance.split()
         cancel_all = any(
-            word in utterance for word in self.all_timers_words
+            word in utterance_words for word in self.all_timers_words
         ) or message.data.get("all")
         active_timer_count = len(self.active_timers)
 


### PR DESCRIPTION
#### Description
The logic that looked for the word "all" in the "cancel all timers" intent was looking in the entire utterance.  This meant commands like "cancel timer sally" evaluated to "all" because it is contained within the word "sally".  This PR will break the utterance up into words so the comparison is made on a word by word basis.

#### Type of PR
If your PR fits more than one category, there is a high chance you should submit more than one PR. Please consider this carefully before opening the PR.
- [X] Bugfix
- [ ] Feature implementation
- [ ] Refactor of code (without functional changes)
- [ ] Documentation improvements
- [ ] Test improvements

#### Testing
Create a timer with a name containing "all".  Cancel that timer.  Only that timer should be cancelled.

#### Documentation
N/A
